### PR TITLE
Update to latest list of vscode elixir extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the "elixir-pack" extension pack will be documented in th
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.3] - 2023-12-28
+Replaced:
+- Removed Elixir-LS and replaced with Lexical Language Server (lexical-lsp.lexical)
+
+Added:
+- Elixir Mix Formatter (animus-coop.vscode-elixir-mix-formatter)
+- Elixir Templates Formatter (royalmist.vscode-eex-format)
+- Phoenix Framework Syntax Highlighting for HEEx (phoenixframework.phoenix)
+- Run on Save (emeraldwalk.runonsave)
+- Workspace Config+ (swellaby.workspace-config-plus)
+- Hover info for Rebar3 and Mix (sztheory.hex-lens)
+- Tailwind CSS IntelliSense (bradlc.vscode-tailwindcss)
+- Lexical - Elixir Language Server (lexical-lsp.lexical)
+- Elixir snippets (florinpatrascu.vscode-elixir-snippets)
+
 ## [0.0.2] - 2021-10-22
 - Updated README.md to include list of extensions this pack manages
 - Added icon

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 This is an extension package for Elixir development.
 
 Installs the follwing packages:
-- Elixir Language Server (jakebecker.elixir-ls)
-- Elixir Credo Support (pantajoe.vscode-elixir-credo)
+
+- Elixir Mix Formatter (animus-coop.vscode-elixir-mix-formatter)
+- Elixir Templates Formatter (royalmist.vscode-eex-format)
 - Hex.pm Intellisense (benvp.vscode-hex-pm-intellisense)
+- Phoenix Framework Syntax Highlighting for HEEx (phoenixframework.phoenix)
+- Run on Save (emeraldwalk.runonsave)
+- Workspace Config+ (swellaby.workspace-config-plus)
+- Hover info for Rebar3 and Mix (sztheory.hex-lens)
+- Tailwind CSS IntelliSense (bradlc.vscode-tailwindcss)
+- Lexical - Elixir Language Server (lexical-lsp.lexical)
+- Elixir snippets (florinpatrascu.vscode-elixir-snippets)
+- Elixir Credo Support (pantajoe.vscode-elixir-credo)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "platypus-coders-elixir-pack",
   "description": "A collection of VSCode extensions to use.",
   "publisher": "platypus-coders",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/icon.jpg",
   "engines": {
@@ -16,9 +16,17 @@
     "Extension Packs"
   ],
   "extensionPack": [ 
-    "pantajoe.vscode-elixir-credo",
-    "jakebecker.elixir-ls",
-    "benvp.vscode-hex-pm-intellisense"
+    "animus-coop.vscode-elixir-mix-formatter",
+    "royalmist.vscode-eex-format",
+    "benvp.vscode-hex-pm-intellisense",
+    "phoenixframework.phoenix",
+    "emeraldwalk.runonsave",
+    "swellaby.workspace-config-plus",
+    "sztheory.hex-lens",
+    "bradlc.vscode-tailwindcss",
+    "lexical-lsp.lexical",
+    "florinpatrascu.vscode-elixir-snippets",
+    "pantajoe.vscode-elixir-credo"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## [0.0.3] - 2023-12-28
Replaced:
- Removed Elixir-LS and replaced with Lexical Language Server (lexical-lsp.lexical)

Added:
- Elixir Mix Formatter (animus-coop.vscode-elixir-mix-formatter)
- Elixir Templates Formatter (royalmist.vscode-eex-format)
- Phoenix Framework Syntax Highlighting for HEEx (phoenixframework.phoenix)
- Run on Save (emeraldwalk.runonsave)
- Workspace Config+ (swellaby.workspace-config-plus)
- Hover info for Rebar3 and Mix (sztheory.hex-lens)
- Tailwind CSS IntelliSense (bradlc.vscode-tailwindcss)
- Lexical - Elixir Language Server (lexical-lsp.lexical)
- Elixir snippets (florinpatrascu.vscode-elixir-snippets)